### PR TITLE
Bug #129757 fix: [TJNotification integration with jticketing-backend]- Display parsing error on notification menu

### DIFF
--- a/src/com_tjnotifications/admin/language/en-GB.com_tjnotifications.ini
+++ b/src/com_tjnotifications/admin/language/en-GB.com_tjnotifications.ini
@@ -90,6 +90,6 @@ COM_TJNOTIFICATIONS_STATE_DISABLE_FAIL_MSG="Cannot enable email status, please f
 COM_TJNOTIFICATIONS_CORE_TEMPLATE="Core Template"
 COM_TJNOTIFICATIONS_CORE_TEMPLATE_CORE_VALUE="Yes"
 COM_TJNOTIFICATIONS_CORE_TEMPLATE_VALUE="No"
-COM_TJNOTIFICATIONS_TAGS_DESC='Enter the tag given on left in to the editor these tag names will be replaced by description given in notification template'
+COM_TJNOTIFICATIONS_TAGS_DESC="Enter the tag given on left in to the editor these tag names will be replaced by description given in notification template"
 COM_TJNOTIFICATIONS_REPLACEMENT_TAGS="Replacement Tag"
 COM_TJNOTIFICATIONS_REPLACEMENT_TAGS_DESC="Description"


### PR DESCRIPTION
Bug #129757 fix: [TJNotification integration with jticketing-backend]- Display parsing error on notification menu