### PR TITLE
Bug #165069 fix: In #__tj_notification_template_configs table saving empty email subject and email body in fresh installation

### DIFF
--- a/src/com_tjnotifications/admin/defines.php
+++ b/src/com_tjnotifications/admin/defines.php
@@ -12,5 +12,5 @@ defined('_JEXEC') or die('Restricted access');
 
 if (!defined('TJNOTIFICATIONS_CONST_BACKENDS_ARRAY'))
 {
-	define('TJNOTIFICATIONS_CONST_BACKENDS_ARRAY', ['email', 'push']);
+	define('TJNOTIFICATIONS_CONST_BACKENDS_ARRAY', ['email', 'sms']);
 }

--- a/src/com_tjnotifications/admin/defines.php
+++ b/src/com_tjnotifications/admin/defines.php
@@ -10,4 +10,7 @@
 // No direct access
 defined('_JEXEC') or die('Restricted access');
 
-define('TJNOTIFICATIONS_CONST_BACKENDS_ARRAY', ['email', 'push']);
+if (!defined('TJNOTIFICATIONS_CONST_BACKENDS_ARRAY'))
+{
+	define('TJNOTIFICATIONS_CONST_BACKENDS_ARRAY', ['email', 'push']);
+}

--- a/src/com_tjnotifications/admin/models/notification.php
+++ b/src/com_tjnotifications/admin/models/notification.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
 
 BaseDatabaseModel::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_tjnotifications/models');
+require_once JPATH_ADMINISTRATOR . '/components/com_tjnotifications/defines.php';
 
 /**
  * notification model.


### PR DESCRIPTION
While installing extension first time  #__tj_notification_template_configs table saving empty email subject and email body in table